### PR TITLE
reset devices on PPIDE interfaces on startup

### DIFF
--- a/ecb/ppide.c
+++ b/ecb/ppide.c
@@ -87,6 +87,10 @@ static void ide_controller_init(disk_controller_t *ctrl, uint16_t base_io)
     ide_set_data_direction(ctrl, true);
 
     printf("PPIDE controller at 0x%x:\n", base_io);
+    *ctrl->control = 1 | (PPIDE_RST_BIT << 1);	// set PC7 (/IRESET)
+    delay_ms(10);
+    *ctrl->control = 0 | (PPIDE_RST_BIT << 1);	// clear PC7 (/IRESET)
+    delay_ms(10);
     disk_controller_startup(ctrl);
 }
 

--- a/include/ecb/ppide.h
+++ b/include/ecb/ppide.h
@@ -26,6 +26,7 @@ struct disk_controller_t
 #define PPIDE_RST_LINE          0x80 // Inverter between 8255 and IDE interface
 #define PPIDE_WR_BIT            5    // (1 << PPIDE_WR_BIT) = PPIDE_WR_LINE
 #define PPIDE_RD_BIT            6    // (1 << PPIDE_RD_BIT) = PPIDE_RD_LINE
+#define PPIDE_RST_BIT           7    // (1 << PPIDE_RST_BIT) = PPIDE_RST_LINE
 
 /* 8255 configuration */
 #define PPIDE_PPI_BUS_READ      0x92


### PR DESCRIPTION
I compiled a bootloader which tested ok with softrom and then I flashed it to the eprom.  But after resetting the board the new bootloader could not detect an IDE drive and also loading an old known working boot loader with softrom could not detect an IDE drive. After some digging I found out that there is no IDE reset and this patch adds that and now all my bootlaoder are working.