### PR TITLE
make dumpmem look like hexdump

### DIFF
--- a/cli/cli_mem.c
+++ b/cli/cli_mem.c
@@ -21,12 +21,17 @@ void pretty_dump_memory(void *start, int len)
         printf("   ");
         lbptr++;
     }
+    if(((unsigned)ptr & 15) > 8)
+        putch(' ');
+
     while(len){
         if(*ptr >= 32 && *ptr < 127)
             *lbptr = *ptr;
         else
             *lbptr = '.';
 
+        if (((unsigned)ptr & 0x0F) == 0x08)
+            putch(' ');
         printf(" %02x", *ptr++);
         len--;
         lbptr++;
@@ -44,14 +49,16 @@ void pretty_dump_memory(void *start, int len)
         }
     }
 
-    rem = 16 - ((unsigned)ptr & 15);
+    rem = 2 + 3 * (16 - ((unsigned)ptr & 15));
 
-    for(i=0; i<rem; i++){
-        printf("   ");
-        *lbptr = ' ';
-        lbptr++;
-    }
-    printf("  %s\n", linebuffer);
+    if (rem >= 26)
+        rem++;
+
+    for(i=0; i<rem; i++)
+        putch(' ');
+
+    *lbptr = 0;
+    puts(linebuffer);
 }
 
 void do_dump(char *argv[], int argc)


### PR DESCRIPTION
add a space in the middle of the hex values to make it more look like hexdump for easier orientation.
also removed the extra spaces on the last line.