### PR TITLE
identify and print status about UART at start

### DIFF
--- a/core/uart.c
+++ b/core/uart.c
@@ -1,6 +1,7 @@
 /* (c) 2023 William R Sowerbutts <will@sowerbutts.com> */
 
 #include <uart.h>
+#include <stdlib.h>
 
 #if defined(TARGET_Q40) /* ISA based targets */
 
@@ -34,15 +35,136 @@ static inline void uart_outb(uint16_t port, uint8_t val) { ecb_write_byte(port, 
 
 #define UART_DIVISOR    (UART_CLK/BAUD_RATE)
 
+char* UARTArray[] = {
+    "unknown",
+    "16450",
+    "16550",
+    "16550A",
+    "16750",
+    "16950",
+    "16950B"
+};
+
+static void serial_icr_write(uint8_t offset, uint8_t value)
+{
+    uart_outb(UART_ADDRESS+UART_SCR, offset);
+    uart_outb(UART_ADDRESS+UART_ICR, value);
+}
+
+static uint8_t serial_icr_read(uint8_t offset)
+{
+    uint8_t value;
+
+    serial_icr_write(UART_ACR, 0 | UART_ACR_ICRRD);	// turn ON ACR[7]
+
+    uart_outb(UART_ADDRESS+UART_SCR, offset);
+    value = uart_inb(UART_ADDRESS+UART_ICR);
+
+    serial_icr_write(UART_ACR, 0);	// turn off ACR[7]
+
+    return value;
+}
+
 void uart_init(void)
 {
+    bool autoflow = true;
+
+    uint8_t FCR = 0xE7;
+    uint8_t LCR = UART_LCR_WLEN8;	// 8N1
+    uint8_t MCR = UART_MCR_DTR|UART_MCR_RTS;	// DTR, RTS
+
+    uint8_t MSR = uart_inb(UART_ADDRESS+UART_MSR);
+    if ((MSR & 0x10) != 0x10) {
+        autoflow = false;
+    }
+
+    uint8_t uart_id = 0;
+
     uart_outb(UART_ADDRESS+UART_IER, 0);                /* disable interrupts */
-    uart_outb(UART_ADDRESS+UART_LCR, 0x80);             /* set DLAB to access divisor */
-    uart_outb(UART_ADDRESS+0, UART_DIVISOR & 0xFF);     /* set divisor LSB */
-    uart_outb(UART_ADDRESS+1, UART_DIVISOR >> 8);       /* set divisor MSB */
-    uart_outb(UART_ADDRESS+UART_LCR, 0x03);             /* clear DLAB, set 8 bit data, 1 stop bit, no parity */
-    uart_outb(UART_ADDRESS+UART_FCR, 0x07);             /* enable and clear RX/TX FIFOs (if present) */
-    uart_outb(UART_ADDRESS+UART_MCR, 0x03);             /* set DTR, RTS */
+
+    uart_outb(UART_ADDRESS+UART_LCR, UART_LCR_CONF_MODE_B);
+    uart_outb(UART_ADDRESS+UART_EFR, 0);
+    uart_outb(UART_ADDRESS+UART_LCR, 0x00);             /* clear DLAB */
+
+    uart_outb(UART_ADDRESS+UART_FCR, UART_FCR_ENABLE_FIFO);
+
+    switch (uart_inb(UART_ADDRESS+UART_IIR) & UART_IIR_FIFO_ENABLED)
+    {
+        case UART_IIR_FIFO_ENABLED_16450:	// 00
+            uart_id = 1;
+            break;
+        case UART_IIR_FIFO_ENABLED_16550:	// 10
+            uart_id = 2;
+            break;
+        case UART_IIR_FIFO_ENABLED_16550A:	// 11
+        {
+            uart_id = 3;
+
+            uart_outb(UART_ADDRESS+UART_LCR, UART_LCR_CONF_MODE_B);
+            if (uart_inb(UART_ADDRESS+UART_EFR) == 0)
+            {
+                uint8_t id1 = 0, id2 = 0, id3 = 0, rev = 0;
+
+                if (autoflow == true)
+                    uart_outb(UART_ADDRESS+UART_EFR, UART_EFR_ECB|UART_EFR_RTS|UART_EFR_CTS);
+                else
+                    uart_outb(UART_ADDRESS+UART_EFR, UART_EFR_ECB|UART_EFR_RTS);
+                uart_outb(UART_ADDRESS+UART_LCR, 0x00);
+
+                id1 = serial_icr_read(UART_ID1);
+                id2 = serial_icr_read(UART_ID2);
+                id3 = serial_icr_read(UART_ID3);
+                rev = serial_icr_read(UART_REV);
+
+                if (id1 == 0x16 && id2 == 0xC9 && id3 == 0x50) {
+                    uart_id = 5;
+                    if (rev == 3) uart_id++; // found a 16C950 rev.B
+
+                    MCR = 0x3; // set DTR and RTS
+                }
+            }
+            break;
+        }
+        default:				// 01
+            uart_id = 0;
+            break;
+    }
+
+    // check for 16C750
+    if (uart_id == 3)
+    {
+        uart_outb(UART_ADDRESS+UART_LCR, UART_LCR_CONF_MODE_B);     /* set needed to activate 64 byte FIFO */
+        uart_outb(UART_ADDRESS+UART_FCR, UART_FCR_ENABLE_FIFO | UART_FCR7_64BYTE);     /* set bit 5 for FIFO 64 bytes enable */
+        uart_outb(UART_ADDRESS+UART_LCR, 0x00);     /* clear LCR */
+
+        if ((uart_inb(UART_ADDRESS+UART_IIR) & 0xe0) == 0xe0)
+            uart_id = 4;
+    }
+
+    if ((uart_id == 3 || uart_id == 4) && autoflow == true)
+        MCR |= UART_MCR_AFE; // set also the AFE bit
+
+    uart_outb(UART_ADDRESS+UART_LCR, UART_LCR_DLAB);   /* set DLAB to access divisor */
+    uart_outb(UART_ADDRESS+0, UART_DIVISOR & 0xFF);    /* set divisor LSB */
+    uart_outb(UART_ADDRESS+1, UART_DIVISOR >> 8);      /* set divisor MSB */
+    uart_outb(UART_ADDRESS+UART_FCR, FCR);             /* enable and clear RX/TX FIFOs (if present) */
+    uart_outb(UART_ADDRESS+UART_LCR, LCR);             /* clear DLAB, set 8 bit data, 1 stop bit, no parity */
+    uart_outb(UART_ADDRESS+UART_MCR, MCR);             /* set DTR, RTS and maybe AFE */
+
+    FCR = uart_inb(UART_ADDRESS+UART_IIR); // FCR/IIR
+    LCR = uart_inb(UART_ADDRESS+UART_LCR);
+    MCR = uart_inb(UART_ADDRESS+UART_MCR);
+
+    uint8_t IER = uart_inb(UART_ADDRESS+UART_IER);
+            MSR = uart_inb(UART_ADDRESS+UART_MSR);
+    uint8_t SCR = uart_inb(UART_ADDRESS+UART_SCR);
+    uint8_t LSR = uart_inb(UART_ADDRESS+UART_LSR);
+
+    printf("\n\nUART: %s, IER=0x%02x IIR=0x%02x LCR=0x%02x MCR=0x%02x LSR=0x%02x MSR=0x%02x SCR=0x%02x \n", UARTArray[uart_id], IER, FCR, LCR, MCR, LSR, MSR, SCR);
+    if (autoflow == false)
+        puts("detected /CTS HIGH, starting without AUTOFLOW ENABLE\n");
+
+    return;
 }
 
 bool uart_write_ready(void)

--- a/include/uart.h
+++ b/include/uart.h
@@ -25,11 +25,48 @@ bool uart_check_cancel_key(void);
 #define UART_LCR        3       /* line control register */
 #define UART_MCR        4       /* modem control register */
 #define UART_LSR        5       /* line status register */
+#define UART_ICR        5       /* index control register */
 #define UART_MSR        6       /* modem status register */
 #define UART_SCR        7       /* scratch register */
 
+/* 16C950 UART hardware register */
+#define UART_ACR        0       /* Additional Control Register */
+#define UART_EFR        2       /* Extended Features Register */
+#define UART_ID1        8       /* UART ID1 */
+#define UART_ID2        9       /* UART ID2 */
+#define UART_ID3        10      /* UART ID3 */
+#define UART_REV        11      /* UART Revision */
+
+#define UART_ACR_ICRRD  0x40    /* ICR Read enable */
+
+#define UART_FCR_ENABLE_FIFO   0x01 /* Enable the FIFO */
 #define UART_LSR_DR     0x01    /* LSR: data ready bit */
+
+#define UART_EFR_ECB    0x10    /* LSR: Enhanced control bit */
+#define UART_EFR_RTS    0x40    /* RTS flow control */
+#define UART_EFR_CTS    0x80    /* CTS flow control */
+
 #define UART_LSR_THRE   0x20    /* LSR: transmit holding register empty */
 #define UART_LSR_TEMT   0x40    /* LSR: transmitter empty */
+
+#define UART_LCR_DLAB          0x80 /* Divisor latch access bit */
+#define UART_LCR_CONF_MODE_A   UART_LCR_DLAB /* Configutation mode A */
+#define UART_LCR_CONF_MODE_B   0xBF /* Configutation mode B */
+#define UART_LCR_WLEN8         0x03 /* Wordlength: 8 bits */
+
+#define UART_MCR_DTR   0x01 /* DTR complement */
+#define UART_MCR_RTS   0x02 /* RTS complement */
+#define UART_MCR_OUT1  0x04 /* Out1 complement */
+#define UART_MCR_OUT2  0x08 /* Out2 complement */
+#define UART_MCR_LOOP  0x10 /* Enable loopback test mode */
+#define UART_MCR_AFE   0x20 /* Enable auto-RTS/CTS (TI16C550C/TI16C750) */
+
+#define UART_FCR7_64BYTE 0x20
+#define UART_IIR_FIFO_ENABLED	0xc0 /* FIFOs enabled / port type identification */
+#define UART_IIR_FIFO_ENABLED_16450	0x00	/* 16450: no FIFO */
+#define UART_IIR_FIFO_ENABLED_16550	0x80	/* 16550: (broken/unusable) FIFO */
+#define UART_IIR_FIFO_ENABLED_16550A	0xc0	/* 16550A: FIFO enabled */
+#define UART_IIR_FIFO_ENABLED_16750	0xe0	/* 16750: 64 bytes FIFO enabled */
+
 
 #endif

--- a/tools/sendrom
+++ b/tools/sendrom
@@ -88,7 +88,9 @@ port.flush()
 
 # report progress
 taken = time.time() - start
-print(f'\rall sent in {taken:.3f} seconds.              ')
+persec = total / taken
+efi = (persec * 100) / (int(sys.argv[2]) / 10)
+print(f'\rall sent in {taken:.3f} seconds. {persec:.0f} bytes/sec. {efi:.3f}% efficency.')
 if '--term' in sys.argv:
     print('---- entering terminal mode ----')
     t = Replica1Terminal(port)


### PR DESCRIPTION
activate FlowControl if other side signals
positive RTS. disable it otherwise.

enable FIFO on 16550A and higher