### PR TITLE
pretty_dump_memory() is reading memory twice.

### DIFF
--- a/cli/cli_mem.c
+++ b/cli/cli_mem.c
@@ -25,14 +25,15 @@ void pretty_dump_memory(void *start, int len)
         putch(' ');
 
     while(len){
-        if(*ptr >= 32 && *ptr < 127)
-            *lbptr = *ptr;
+        uint8_t voi = *ptr++;
+        if(voi >= 32 && voi < 127)
+            *lbptr = voi;
         else
             *lbptr = '.';
 
         if (((unsigned)ptr & 0x0F) == 0x08)
             putch(' ');
-        printf(" %02x", *ptr++);
+        printf(" %02x", voi);
         len--;
         lbptr++;
 


### PR DESCRIPTION
pretty_dump_memory() would access memory twice for reading the value to display as hex and as ascii. but for hardware register this would be bad for testing. changed the code so that the memory is only read once.