### PR TITLE
Update cli_mem.c

### DIFF
--- a/cli/cli_mem.c
+++ b/cli/cli_mem.c
@@ -25,14 +25,14 @@ void pretty_dump_memory(void *start, int len)
         putch(' ');
 
     while(len){
+        if (((unsigned)ptr & 0x0F) == 0x08)
+            putch(' ');
         uint8_t voi = *ptr++;
         if(voi >= 32 && voi < 127)
             *lbptr = voi;
         else
             *lbptr = '.';
 
-        if (((unsigned)ptr & 0x0F) == 0x08)
-            putch(' ');
         printf(" %02x", voi);
         len--;
         lbptr++;


### PR DESCRIPTION
after my last patch the split in the memory dump was now on 7/9 and not 8/8. fixed that.